### PR TITLE
Hide the 2016 signup link for now.

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,8 +79,8 @@
 				<div class="col-12">
 					<form role="form">
 						<div class="form-group" style="color:black">
-							<a href="/signup" class="btn btn-info btn-lg btn-signup"
-								 onClick="window.location.href='/2016/checkin'">CheckIn for 2016</a>
+							<!--<a href="/signup" class="btn btn-info btn-lg btn-signup"
+								 onClick="window.location.href='/2016/checkin'">CheckIn for 2016</a>-->
 							<div class="row">
 								<div class="col-12">
 									<p>Things you can do:</p>


### PR DESCRIPTION
There's no point in sending people to the 2016 signup page. Hillhacks
2016 (and indeed 2016 itself) is over.