### PR TITLE
Enable the checkin link

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,8 +80,8 @@
 				<div class="col-12">
 					<form>
 						<div class="form-group" style="color:black">
-							<!--<a href="/signup" class="btn btn-info btn-lg btn-signup"
-								 onClick="window.location.href='/2016/checkin'">CheckIn for 2016</a>-->
+							<a href="/2017/checkin" class="btn btn-info btn-lg btn-signup"
+								 onClick="window.location.href='/2016/checkin'">Sign up for 2017</a>
 							<div class="row">
 								<div class="col-12">
 									<p>Things you can do:</p>


### PR DESCRIPTION
Link to the 2017 checkin page.
In 2016 we had a signup and a checkin page, for no obvious reason. Let's
just link directly to the checkin page now, so people interested in
attending only need to sign up once.